### PR TITLE
Channel Info deprecation, conversation inclusion

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -51,6 +51,7 @@ var controller = Botkit.slackbot({
   debug: false,
   logger: { log: bkLog },
   storage: require('botkit-storage-mongo')({ mongoUri: process.env.MONGODB_URI, tables: ['standups']}),
+  clientSigningSecret: process.env.SLACK_TOKEN,
 });
 
 var webserver = require(`${__dirname}/components/express_webserver.js`)(controller);

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,13 +2,13 @@
 
 ## Creating or rescheduling a standup
 
-To create a new standup or reschedule one, first ensure that the bot is in the channel that the standup is for.  Then say:
+To create a new standup or reschedule one, first ensure that the bot is in said channel. To invite the bot to the channel just send them a direct mention (ie @Standup Steve or whatever the bots username is).  Then say:
 
-`@Standup Steve schedule standup 10am`
+`@Standup Steve schedule/create standup 10am`
 
 Additionally, you can schedule the standups for just certain days of the week:
 
-`@Standup Steve schedule standup 10am M W F`
+`@Standup Steve schedule/create standup 10am M W F`
 
 Some things to note:
 
@@ -44,6 +44,12 @@ To remove a standup and stop reporting on it, in the channel, say:
 - There is no confirmation, so be sure!
 - User standups that have already been recorded will not be deleted
 - You can say "delete" instead of "remove"
+
+## Toggle the Channel Alert Functionality
+
+The bot is defaulted to send reminders out for the standup with an `@here` announcement. This can be toggled on/off by saying:
+
+`@Standup Steve toggle alert`
 
 ## Interacting with the bot
 

--- a/repositories/conversation.js
+++ b/repositories/conversation.js
@@ -1,0 +1,16 @@
+class Conversation {
+  static getInfo(bot, message) {
+    return new Promise((resolve, reject) => {
+      bot.api.conversations.info({ channel: message.channel }, (error, channelInfo) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(channelInfo);
+        }
+      })
+    })
+  };
+};
+
+
+module.exports = Conversation;

--- a/skills/joinChannel.js
+++ b/skills/joinChannel.js
@@ -2,6 +2,7 @@ const log = require('../logger')('custom:joinChannel');
 const _ = require('lodash');
 const common = require('../helpers/common');
 const Channel = require('../repositories/channel');
+const Conversation = require('../repositories/conversation');
 const User = require('../repositories/user');
 
 // TODO: deleted user test
@@ -22,9 +23,11 @@ function createNewUsers(bot, userIds) {
 };
 
 async function fetchChannelNameFromApi(bot, message) {
-  const channelInfo = await Channel.getInfo(bot, message);
+  // depreciated => https://api.slack.com/changelog/2018-09-more-reasons-to-be-a-conversations-api-convert
+  // const channelInfo = await Channel.getInfo(bot, message);
+  // if (!channelInfo.channel.members.length === 0) await createNewUsers(bot, channelInfo.channel.members);
 
-  if (!channelInfo.channel.members.length === 0) await createNewUsers(bot, channelInfo.channel.members);
+  const channelInfo = await Conversation.getInfo(bot, message);
 
   return channelInfo.channel.name;
 }
@@ -57,7 +60,7 @@ async function joinChannel(bot, message) {
 };
 
 function attachSkill(controller) {
-  controller.on(['bot_channel_join'], joinChannel);
+  controller.on(['member_joined_channel'], joinChannel);
   log.verbose('ATTACHED');
 };
 

--- a/tests/createChannelStandup.test.js
+++ b/tests/createChannelStandup.test.js
@@ -7,6 +7,15 @@ const moment = require('moment-timezone');
 
 const controller = Botmock({});
 const testBot = controller.spawn({type: 'slack', token: 'test_token'});
+const data = {
+  'ok': true,
+  'channel': {
+    'id': 'C0VHNJ7MF',
+    'name': 'test1name'
+  }
+}
+
+testBot.api.setData('conversations.info', data);
 
 describe('create channel standup funcitonality', () => {
   describe('createNewStandup', () => {

--- a/tests/getStandupInfo.test.js
+++ b/tests/getStandupInfo.test.js
@@ -23,7 +23,15 @@ const message3 = {
       '11am',
     ]
 };
+const data = {
+  'ok': true,
+  'channel': {
+    'id': 'C0VHNJ7MF',
+    'name': 'test1name'
+  }
+}
 
+testBot.api.setData('conversations.info', data);
 joinChannel(testBot, message1);
 
 describe('get standup info funcitonality', () => {

--- a/tests/joinChannel.test.js
+++ b/tests/joinChannel.test.js
@@ -36,6 +36,14 @@ describe('join channel funcitonality', () => {
       const message = {
         channel: 'C0HBYC9SA3'
       };
+      const data = {
+        'ok': true,
+        'channel': {
+          'id': 'C0VHNJ7MF',
+          'name': 'test1name'
+        }
+      }
+      await testBot.api.setData('conversations.info', data);
 
       expect(await fetchChannelNameFromApi(testBot, message)).toEqual('test1name');
     });

--- a/tests/removeStandup.test.js
+++ b/tests/removeStandup.test.js
@@ -26,6 +26,15 @@ const message3 = {
       '11am',
     ]
 };
+const data = {
+  'ok': true,
+  'channel': {
+    'id': 'C0VHNJ7MF',
+    'name': 'test1name'
+  }
+}
+
+testBot.api.setData('conversations.info', data);
 
 describe('create channel standup', () => {
   test('replies that there is no standup scheduled if standup is not present', async () => {

--- a/tests/setReminder.test.js
+++ b/tests/setReminder.test.js
@@ -27,6 +27,15 @@ const message3 = {
       '11am',
     ]
 };
+const data = {
+  'ok': true,
+  'channel': {
+    'id': 'C0VHNJ7MF',
+    'name': 'test1name'
+  }
+}
+
+testBot.api.setData('conversations.info', data);
 
 describe.only('set channel reminder time', () => {
   test('replies that there is no standup scheduled if standup is not present', async () => {

--- a/tests/toggleHereChannelAlert.test.js
+++ b/tests/toggleHereChannelAlert.test.js
@@ -27,6 +27,15 @@ const message3 = {
       '11am',
     ]
 };
+const data = {
+  'ok': true,
+  'channel': {
+    'id': 'C0VHNJ7MF',
+    'name': 'test1name'
+  }
+}
+
+testBot.api.setData('conversations.info', data);
 
 describe.only('toggle here channel alert', () => {
   test('replies that there is no standup scheduled if standup is not present', async () => {


### PR DESCRIPTION
baseline fix for channel info deprecation, inclusion of private channels due to this identified issue: https://api.slack.com/changelog/2018-09-more-reasons-to-be-a-conversations-api-convert